### PR TITLE
Validation.exists(0n) now returns true

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ Checks if a value exists.
     validation.exists('foobar')                   // true
     validation.exists(function() {})              // true
     validation.exists(0)                          // true
+    validation.exists(0n)                         // true
     validation.exists(-1)                         // true
     validation.exists(null)                       // false
     validation.exists(undefined)                  // false

--- a/index.js
+++ b/index.js
@@ -47,11 +47,12 @@ exports.isType = function (value, type) {
  * 
  *     validation.exists('foobar')  // true
  *     validation.exists(0)         // true
+ *     validation.exists(0n)        // true
  *     validation.exists(null)      // false
  *     validation.exists(undefined) // false
  * 
  */
 
 exports.exists = function (value) {
-  return !!(value || value === 0);
+  return !!(value || value === 0 || value === 0n);
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Ritchie Martori <ritchie@deployd.com> (deployd.com)",
   "name": "validation",
   "description": "simple validation functions",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/ritch/validation.git"


### PR DESCRIPTION
Previously if 0n, 0 as a bigint, was passed into exists it returned false. This was obviously unintended behavior based on the fact that 0 was supposed to return true. This PR fixes that simple problem.