### PR TITLE
Add Mocha and Chai testing dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "node": "*"
   },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^8.1.3"
+  },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
Currently testing requires the tester to manually install both Chai and Mocha, adding them as dev depencies makes it so they can just do npm install.